### PR TITLE
Call req-package-finish outside of load-dir

### DIFF
--- a/init-real.el
+++ b/init-real.el
@@ -77,5 +77,6 @@
   (setq load-dir-recursive t)
   :config
   (load-dir-one my-init-dir)
-  (req-package-finish)
   (funcall 'select-theme))
+
+(req-package-finish)


### PR DESCRIPTION
Without this, it seems that - from a blank slate - no subsequent `req-package` calls seem to actually work/install anything (so I get error messages about packages not being found).

I'm not sure if the `(funcall 'select-theme)` line should be moved out as well though.